### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+
 addons:
   apt:
     packages:
@@ -8,10 +11,10 @@ env:
 
 before_install:
   # install LXC
-  - sudo apt-get install software-properties-common python-software-properties
+  - sudo apt-get install -y software-properties-common python-software-properties
   - sudo add-apt-repository -y ppa:ubuntu-lxc/stable
   - sudo apt-get update -qq
-  - sudo apt-get install -y lxc-dev
+  - sudo apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" lxc-dev
   # Download and unpack the stack executable
   - mkdir -p ~/.local/bin
   - export PATH=$HOME/.local/bin:$PATH


### PR DESCRIPTION
I've changed travis building environment to newer ubuntu version and it seems to work.

I had some troubles with apt interactive mode - I wasn't able to force it with `env: - DEBIAN_FRONTEND=noninteractive`, so I've added `-y` to every `apt-get` invocation.