### PR TITLE
Remove superfluous CBool definition

### DIFF
--- a/src/Bindings/LXC/Sys/Types.hsc
+++ b/src/Bindings/LXC/Sys/Types.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 #include <bindings.dsl.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -16,7 +18,9 @@
 module Bindings.LXC.Sys.Types where
 #strict_import
 
+#if __GLASGOW_HASKELL__ < 802
 type CBool = CInt
+#endif
 
 #integral_t pid_t
 #integral_t uint64_t


### PR DESCRIPTION
Since commit ghc/ghc@0d769d5b96232ee0fe5a44f2ce5717bdb0e7eaa3
Foreign.C.Types defines their own CBool.
This PR fixes `Ambiguous occurrence 'CBool'` errors resulting from that.